### PR TITLE
PR - Add vacancy field in necessary pages

### DIFF
--- a/templates/jobs/create.html
+++ b/templates/jobs/create.html
@@ -108,7 +108,7 @@
                             </div>
                         </div>
                         <div class="row">
-                            <div class="col-lg-12 form-group">
+                            <div class="col-lg-6 form-group">
                                 <label for="category">Category</label>
                                 <select id="category" name="category" class="form-control select2">
                                     <option value="web-design" {% if form.category.value == "web-design" %}
@@ -130,6 +130,11 @@
                                             selected {% endif %}>Android
                                     </option>
                                 </select>
+                            </div>
+                            <div class="col-lg-6 form-group">
+                                <label for="vacancy">Vacancy: </label>
+                                <input id="vacancy" name="vacancy" type="number" min="1" class="form-control"
+                                        value="{{ form.vacancy.value | default_if_none:"" }}">
                             </div>
                         </div>
                         <div class="row">

--- a/templates/jobs/details.html
+++ b/templates/jobs/details.html
@@ -31,6 +31,7 @@
                 <div class="col-lg-8">
                     <h3>Category: {{ job.category }}</h3>
                     <h5>Last date: {{ job.last_date|date }}</h5>
+                    <h5 style="color: blueviolet;">Vacancy: {{ job.vacancy }}</h5>
                     <h5 class="text-info">Salary: {% if job.salary > 0 %} {{ job.salary | intcomma}}/Monthly {% else %} Negotiable {% endif %} </h5>
                     Tags:
                     {% for tag in job.tags.all %}

--- a/templates/jobs/employer/dashboard.html
+++ b/templates/jobs/employer/dashboard.html
@@ -33,6 +33,7 @@
                                 <th>Position filled</th>
                                 <th>Date posted</th>
                                 <th>Date expiring</th>
+                                <th>Vacancy</th>
                                 <th>Applicants</th>
                                 <th>Actions</th>
                             </tr>
@@ -52,6 +53,7 @@
                                     </td>
                                     <td>{{ job.created_at }}</td>
                                     <td>{{ job.last_date }}</td>
+                                    <td>{{ job.vacancy }}</td>
                                     <td>
                                         <a href="{% url 'jobs:employer-dashboard-applicants' job.id %}"
                                            class="btn btn-success">

--- a/templates/jobs/update.html
+++ b/templates/jobs/update.html
@@ -96,7 +96,7 @@
 
                         </div>
                         <div class="row">
-                            <div class="col-lg-12 form-group">
+                            <div class="col-lg-6 form-group">
                                 <label for="category">Category</label>
                                 <select id="category" name="category" class="form-control">
                                     <option value="web-design" {% if form.category.value == "web-design" %} selected {% endif %}>Web design</option>
@@ -106,6 +106,11 @@
                                     <option value="support" {% if form.category.value == "support" %} selected {% endif %}>Support</option>
                                     <option value="android" {% if form.category.value == "android" %} selected {% endif %}>Android</option>
                                 </select>
+                            </div>
+                            <div class="col-lg-6 form-group">
+                                <label for="vacancy">Vacancy: </label>
+                                <input id="vacancy" name="vacancy" type="number" min="1" class="form-control"
+                                        value="{{ form.vacancy.value | default_if_none:"" }}">
                             </div>
                         </div>
                         <div class="row">


### PR DESCRIPTION
This PR fixes #60 issue

We have added vacancy field in the places mentioned below - 
1. create job post page
2. job detail page
3. update job post page
4. employer dashboard table 

### Screenshots: 
![update_job](https://user-images.githubusercontent.com/30120066/198336356-72bc53c3-ded4-46d0-90c1-cb0d49505116.jpg)
![dashboard_vacancy](https://user-images.githubusercontent.com/30120066/198336368-052bbb32-3cfd-4fa9-bba8-5d947e561ea7.jpg)
![vacancy](https://user-images.githubusercontent.com/30120066/198336339-7de83311-cade-47c9-af17-6c310ec9c8e5.jpg)

